### PR TITLE
Suggestions for Section 508 Compliance

### DIFF
--- a/login-nocaptcha.php
+++ b/login-nocaptcha.php
@@ -142,14 +142,14 @@ class LoginNocaptcha {
         echo '      <div style="width: 100%; height: 422px; position: relative;">'."\n";
         echo '          <div style="width: 302px; height: 422px; position: relative;">'."\n";
         echo sprintf('              <iframe src="https://www.google.com/recaptcha/api/fallback?k=%s"', get_option('login_nocaptcha_key'))."\n";
-        echo '                  frameborder="0" scrolling="no"'."\n";
+        echo '                  frameborder="0" title="captcha" scrolling="no"'."\n";
         echo '                  style="width: 302px; height:422px; border-style: none;">'."\n";
         echo '              </iframe>'."\n";
         echo '          </div>'."\n";
         echo '          <div style="width: 100%; height: 60px; border-style: none;'."\n";
         echo '              bottom: 12px; left: 25px; margin: 0px; padding: 0px; right: 25px; background: #f9f9f9; border: 1px solid #c1c1c1; border-radius: 3px;">'."\n";
         echo '              <textarea id="g-recaptcha-response" name="g-recaptcha-response"'."\n";
-        echo '                  class="g-recaptcha-response"'."\n";
+        echo '                  title="response" class="g-recaptcha-response"'."\n";
         echo '                  style="width: 250px; height: 40px; border: 1px solid #c1c1c1;'."\n";
         echo '                  margin: 10px 25px; padding: 0px; resize: none;" value="">'."\n";
         echo '              </textarea>'."\n";


### PR DESCRIPTION
1) WCAG 2.0 A F68 Section 508 (2017) A F68
A programmatically determined name allows screen readers to tell the user what the control does. To add a name do one of the following:

Added a TITLE attribute

2) WCAG 2.0 A 2.4.1 Section 508 (2017) A 2.4.1
Added a TITLE attribute to IFRAME element (e.g. TITLE="Main Content"). Without a TITLE some screen readers read out the FRAME filename, which is usually meaningless. IFRAMEs with no title cause problems in:

JAWS 14 and 15 with Firefox (the frame SRC filename is read instead)
VoiceOver on OSX 10.9 (a meaningless title like "Frame twelve" is read out)