### PR TITLE
Style user registration form

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,5 @@
 #lostpasswordform div.g-recaptcha,
-#loginform div.g-recaptcha {
+#loginform div.g-recaptcha,
+#registerform div.g-recaptcha {
         margin: 12px 0 24px -15px;
 }

--- a/login-nocaptcha.php
+++ b/login-nocaptcha.php
@@ -155,7 +155,7 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
     public static function register_scripts_css() {
         $api_url = 'https://www.google.com/recaptcha/api.js?onload=submitDisable';
         wp_register_script('login_nocaptcha_google_api', $api_url, array(), null );
-        wp_register_style('login_nocaptcha_css', plugin_dir_url( __FILE__ ) . 'css/style.css');
+        wp_register_style('login_nocaptcha_css', plugin_dir_url( __FILE__ ) . 'css/style.css', array( 'login' ), filemtime( __FILE__ ));
     }
 
     public static function enqueue_scripts_css() {
@@ -163,7 +163,7 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
             LoginNocaptcha::register_scripts_css();
         }
         if ( (!empty($GLOBALS['pagenow']) && ($GLOBALS['pagenow'] == 'options-general.php' ||
-                $GLOBALS['pagenow'] == 'wp-login.php')) || 
+                $GLOBALS['pagenow'] == 'wp-login.php')) ||
                 (function_exists('is_account_page') && is_account_page()) ||
                 (function_exists('is_checkout') && is_checkout())
             ) {
@@ -199,7 +199,7 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
             echo "                     button.removeAttribute('disabled');\n";
             echo "                 }\n";
             if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
-                echo "                 var woo_buttons = ".json_encode(array('.woocommerce-form-login button','.woocommerce-form-register button','.woocommerce-ResetPassword button')).";\n"; 
+                echo "                 var woo_buttons = ".json_encode(array('.woocommerce-form-login button','.woocommerce-form-register button','.woocommerce-ResetPassword button')).";\n";
                 echo "                 if (typeof jQuery != 'undefined') {\n";
                 echo "                     jQuery.each(woo_buttons,function(i,btn) {\n";
                 echo "                         jQuery(btn).removeAttr('disabled');\n";
@@ -219,7 +219,7 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
             echo "                     button.setAttribute('disabled','disabled');\n";
             echo "                 }\n";
             if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
-                echo "                 var woo_buttons = ".json_encode(array('.woocommerce-form-login button','.woocommerce-form-register button','.woocommerce-ResetPassword button')).";\n"; 
+                echo "                 var woo_buttons = ".json_encode(array('.woocommerce-form-login button','.woocommerce-form-register button','.woocommerce-ResetPassword button')).";\n";
                 echo "                 if (typeof jQuery != 'undefined') {\n";
                 echo "                     jQuery.each(woo_buttons,function(i,btn) {\n";
                 echo "                        jQuery(btn).attr('disabled','disabled');\n";
@@ -356,7 +356,7 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
     public static function admin_notices() {
         // not working, or notice fired in last 30 seconds
         $login_nocaptcha_error = get_option('login_nocaptcha_error');
-        $login_nocaptcha_working = get_option('login_nocaptcha_working'); 
+        $login_nocaptcha_working = get_option('login_nocaptcha_working');
         $login_nocaptcha_notice = get_option('login_nocaptcha_notice');
         $time = time();
         if(!empty($login_nocaptcha_error) && (empty($login_nocaptcha_working) || ($time - $login_nocaptcha_notice < 30))) {


### PR DESCRIPTION
The plugin currently [provides CSS styles](https://github.com/cyberscribe/login-recaptcha/blob/master/css/style.css) for the login and lost-password forms, but the registration form for new users (if enabled) looked a bit off:

<img width="416" alt="screenshot-20191229-104816" src="https://user-images.githubusercontent.com/308422/71555161-12767400-2a29-11ea-82fc-aafed6e180e2.png">

This PR simply adds the CSS selector for the registration form to the existing stylesheet, thus ensuring the reCaptcha is being displayed nicely as on the login form:

<img width="391" alt="screenshot-20191229-105901" src="https://user-images.githubusercontent.com/308422/71555244-5453ea00-2a2a-11ea-9b84-a942c1bd7113.png">
