### PR TITLE
Flush previous error messages to hide authentication status

### DIFF
--- a/login-nocaptcha.php
+++ b/login-nocaptcha.php
@@ -302,7 +302,7 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
                     if ( isset($g_response->{'error-codes'}) && $g_response->{'error-codes'} && in_array('missing-input-response', $g_response->{'error-codes'})) {
                         update_option('login_nocaptcha_working', true);
                         if (is_wp_error($user_or_email)) {
-                            $user_or_email->add('no_captcha', __('<strong>ERROR</strong>&nbsp;: Please check the ReCaptcha box.','login-recaptcha'));
+                            $user_or_email = new WP_Error('no_captcha', __('<strong>ERROR</strong>&nbsp;: Please check the ReCaptcha box.','login-recaptcha'));
                             return $user_or_email;
                         } else {
                             return new WP_Error('authentication_failed', __('<strong>ERROR</strong>&nbsp;: Please check the ReCaptcha box.','login-recaptcha'));
@@ -319,7 +319,7 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
                     } else if( isset($g_response->{'error-codes'})) {
                         update_option('login_nocaptcha_working', true);
                         if (is_wp_error($user_or_email)) {
-                            $user_or_email->add('invalid_captcha', __('<strong>ERROR</strong>&nbsp;: Incorrect ReCaptcha, please try again.','login-recaptcha'));
+                            $user_or_email = new WP_Error('invalid_captcha', __('<strong>ERROR</strong>&nbsp;: Incorrect ReCaptcha, please try again.','login-recaptcha'));
                             return $user_or_email;
                         } else {
                             return new WP_Error('authentication_failed', __('<strong>ERROR</strong>&nbsp;: Incorrect ReCaptcha, please try again.','login-recaptcha'));

--- a/login-nocaptcha.php
+++ b/login-nocaptcha.php
@@ -302,8 +302,7 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
                     if ( isset($g_response->{'error-codes'}) && $g_response->{'error-codes'} && in_array('missing-input-response', $g_response->{'error-codes'})) {
                         update_option('login_nocaptcha_working', true);
                         if (is_wp_error($user_or_email)) {
-                            $user_or_email = new WP_Error('no_captcha', __('<strong>ERROR</strong>&nbsp;: Please check the ReCaptcha box.','login-recaptcha'));
-                            return $user_or_email;
+                            return new WP_Error('no_captcha', __('<strong>ERROR</strong>&nbsp;: Please check the ReCaptcha box.','login-recaptcha'));
                         } else {
                             return new WP_Error('authentication_failed', __('<strong>ERROR</strong>&nbsp;: Please check the ReCaptcha box.','login-recaptcha'));
                         }
@@ -319,8 +318,7 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
                     } else if( isset($g_response->{'error-codes'})) {
                         update_option('login_nocaptcha_working', true);
                         if (is_wp_error($user_or_email)) {
-                            $user_or_email = new WP_Error('invalid_captcha', __('<strong>ERROR</strong>&nbsp;: Incorrect ReCaptcha, please try again.','login-recaptcha'));
-                            return $user_or_email;
+                            return new WP_Error('invalid_captcha', __('<strong>ERROR</strong>&nbsp;: Incorrect ReCaptcha, please try again.','login-recaptcha'));
                         } else {
                             return new WP_Error('authentication_failed', __('<strong>ERROR</strong>&nbsp;: Incorrect ReCaptcha, please try again.','login-recaptcha'));
                         }


### PR DESCRIPTION
As this plugin doesn't stop brute-force attack, but we should try to hide exact authentication status from brute force attacker.

see in these three screenshots, attacker clearly know whats going on, he can track when there is only recaptcha error, means my username-pwd are correct, attacker can stop brute-force script and try loggin in with that username-pwd.

attacker knows my username is not correct - https://nimb.ws/BtrT8S
attacker knows my username is correct but password not – https://nimb.ws/7XVf8t
Attacker knows my username and password is correct - just captcha is missing – https://nimb.ws/pBbkMw

so instead that, we can only show recaptcha error, when recaptcha is in error and flush previous messages.