### PR TITLE
Fix too high priority hook on WC registration form

### DIFF
--- a/login-nocaptcha.php
+++ b/login-nocaptcha.php
@@ -51,7 +51,7 @@ class LoginNocaptcha {
             update_option('login_nocaptcha_message_type', 'notice-error');
             update_option('login_nocaptcha_error', sprintf(__('Login NoCaptcha has not been properly configured. <a href="%s">Click here</a> to configure.','login-recaptcha'), 'options-general.php?page=login-recaptcha/admin.php'));
             add_action('woocommerce_register_post',array('LoginNocaptcha', 'authenticate'));
-add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form'));
+            add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form'), 30);
         }
 
     }
@@ -62,7 +62,7 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
             add_action('woocommerce_login_form',array('LoginNocaptcha', 'nocaptcha_form'));
             add_action('woocommerce_lostpassword_form',array('LoginNocaptcha', 'nocaptcha_form'));
             add_action('woocommerce_register_post',array('LoginNocaptcha', 'woo_authenticate'), 10, 3);
-            add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form'));
+            add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form'), 30);
         }
     }
 


### PR DESCRIPTION
The plugin hooks to `woocommerce_register_form` with default priority (10?) which is higher than what `wc_registration_privacy_policy_text` uses (20). This results in reCAPTCHA being rendered between the form fields and privacy text in WooCommerce user registration form.

IMO the reCAPTCHA should be between privacy text and Register button. This pull request fixes that.