### PR TITLE
Use `htmlspecialchars()` instead of deprecated `filter_var()`

### DIFF
--- a/login-nocaptcha.php
+++ b/login-nocaptcha.php
@@ -119,7 +119,8 @@ add_action('woocommerce_register_form',array('LoginNocaptcha', 'nocaptcha_form')
     }
 
     public static function filter_whitelist( $string ) {
-        return preg_replace( '/[ \t]/', '', trim(filter_var($string, FILTER_SANITIZE_STRING)) ); //must consist of valid string characters, remove spaces
+        // must consist of valid string characters, remove spaces
+        return preg_replace('/[ \t]/', '', trim( htmlspecialchars( $string, ENT_QUOTES ) ) );
     }
 
     public static function get_ip_address() {


### PR DESCRIPTION
This PR replaces `filter_var($string, FILTER_SANITIZE_STRING)` that was deprecated at PHP 8.1 with `htmlspecialchars()`.

# Ref

- https://wordpress.org/support/topic/deprecation-notice-on-php-8-1-2/
- https://wordpress.org/support/topic/deprecation-notice-on-php-8-2/